### PR TITLE
Grammar fix on hotkeys.py

### DIFF
--- a/utils/hotkeys.py
+++ b/utils/hotkeys.py
@@ -421,7 +421,7 @@ def input_change_listener_sensitivity():
         SPEAKING_VOLUME_SENSITIVITY = 104
     elif SPEAKING_VOLUME_SENSITIVITY >= 104:
         SPEAKING_VOLUME_SENSITIVITY = 9
-    print("\nSensitivity Set To " + str(SPEAKING_VOLUME_SENSITIVITY) + " !")
+    print("\nSensitivity Set To " + str(SPEAKING_VOLUME_SENSITIVITY) + "!")
 
 
 def input_change_listener_sensitivity_from_ui(value):
@@ -429,7 +429,7 @@ def input_change_listener_sensitivity_from_ui(value):
 
     SPEAKING_VOLUME_SENSITIVITY = value
 
-    print("\nSensitivity Set To " + str(SPEAKING_VOLUME_SENSITIVITY) + " !")
+    print("\nSensitivity Set To " + str(SPEAKING_VOLUME_SENSITIVITY) + "!")
 
 
 


### PR DESCRIPTION
Fixed the most pressing issue with the program. You are welcome /j

The capitalization on each word is better for dyslexic people or something like that, right? I almost changed it too, but I remembered this random fact.