### PR TITLE
Fixed None and string on web_ui.py

### DIFF
--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -160,7 +160,10 @@ with gr.Blocks(theme=based_theme, title="Z-Waif UI") as demo:
 
 
         def change_autochat_sensitivity(autochat_sens):
-
+            
+            if not is_integer(autochat_sens): #band-aid fix, but it just works TM
+                autochat_sens = 4
+            
             utils.hotkeys.input_change_listener_sensitivity_from_ui(autochat_sens)
             return
 


### PR DESCRIPTION
If you input a string or nothing in Auto-Chat Sensitivity, python throws an error. The program doesn't crash, but this should prevent users from being scared by the error.

Btw, I tried to put this check in other places, but it didn't really work. I think it looks ugly here, but again, it's a band-aid XD